### PR TITLE
Update wsse.js

### DIFF
--- a/wsse.js
+++ b/wsse.js
@@ -301,6 +301,8 @@ function isodatetime() {
     var hour = today.getHours();
     var hourUTC = today.getUTCHours();
     var diff = hour - hourUTC;
+    if(diff > 12) diff -= 24; // Fix the problem for town with real negative diff
+    if(diff <= -12) diff += 24; // Fix the problem for town with real positive diff
     var hourdifference = Math.abs(diff);
     var minute = today.getMinutes();
     var minuteUTC = today.getUTCMinutes();


### PR DESCRIPTION
At the line 313, there is difference between the current hour and the UTC hour. That woks most of the time but there is some specific moment where it does not give the right result. Note that JS return hour base on 24 hours not 12am and 12pm in this case.

Here is the explanation:
Any town where the difference is -4. It works all the time except between 8pm and midnight. 
Anytime : hour - hourUTC = -4
At 8pm : 20 - 00 = 20
At 9pm : 21 - 01 = 20
...

Same thing for any other minus number, as example difference of -8. 
Anytime : hour - hourUTC = -8
At 8pm : 16 - 00 = 16
At 9pm : 21 - 05 = 16
...

You can change value for city with different time like -6 or -11, you'll face the problem, but at different time of the day, when the UTC get at 00 and up to the time where the current hour reach midnight itself.

The same problem for the positive difference, but at different time again. As example, +11
Anytime : hour - hourUTC = +11
At 8pm : 10 - 23 = -13
At 9pm : 11 - 24 = -13
...

To fix that, we can just add this in the code : 
var diff = hour - hourUTC; // That's ok
if(diff > 12) diff -= 24; // Fix the problem for town with real negative diff
if(diff <= -12) diff += 24; // Fix the problem for town with real positive diff
